### PR TITLE
Fixing timestamp bug

### DIFF
--- a/pipeline/test_transform.py
+++ b/pipeline/test_transform.py
@@ -1,9 +1,7 @@
 """Test suite for the transform.py script, covering a range of possible errors in the
 attained data from the log lines, as well as missing/incomplete data."""
 
-from datetime import datetime, timedelta
-from unittest.mock import MagicMock
-
+from datetime import datetime
 
 from transform import timestamp_to_date, check_datetime_is_valid, extract_datetime_from_string, \
     get_bike_serial_number_from_log_line, get_email_from_log_line, get_user_from_log_line, \

--- a/pipeline/test_transform.py
+++ b/pipeline/test_transform.py
@@ -2,6 +2,8 @@
 attained data from the log lines, as well as missing/incomplete data."""
 
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
 
 from transform import timestamp_to_date, check_datetime_is_valid, extract_datetime_from_string, \
     get_bike_serial_number_from_log_line, get_email_from_log_line, get_user_from_log_line, \
@@ -13,18 +15,22 @@ def test_convert_epoch_to_datetime():
 
     assert timestamp_to_date(0) == datetime(year=1970, month=1, day=1).date()
 
-    assert timestamp_to_date(1609459200000) == datetime(year=2021, month=1, day=1).date()
+    assert timestamp_to_date(1609459200000) == datetime(
+        year=2021, month=1, day=1).date()
 
-    assert timestamp_to_date(1612137600000) == datetime(year=2021, month=2, day=1).date()
+    assert timestamp_to_date(1612137600000) == datetime(
+        year=2021, month=2, day=1).date()
 
-    assert timestamp_to_date(1614556800000) == datetime(year=2021, month=3, day=1).date()
+    assert timestamp_to_date(1614556800000) == datetime(
+        year=2021, month=3, day=1).date()
 
     # Test with current time
     current_time = int(datetime.utcnow().timestamp() * 1000)
     assert timestamp_to_date(
         current_time) == datetime.now().date()
 
-    assert timestamp_to_date(-631152000000) == datetime(year=1950, month=1, day=1).date()
+    assert timestamp_to_date(-631152000000) == datetime(year=1950,
+                                                        month=1, day=1).date()
 
 
 def test_valid_datetime_object():
@@ -144,32 +150,6 @@ def test_get_valid_user_data_from_log_line():
           'birthdate': datetime(year=1959, month=5, day=2).date(), 'height': 187, 'weight': 52,
           'email': 'wayne_fitzgerald@hotmail.com', 'gender': 'male',
           'account_created': datetime(year=2022, month=1, day=4).date()}
-
-
-def test_valid_ride_data_from_log_line():
-    """Test for the get_ride_data_from_log_line function where all fields are present."""
-
-    assert get_ride_data_from_log_line(
-        "2022-07-25 16:13:37.209120 mendoza v9: [SYSTEM] data = \
-        {\"user_id\":815,\"name\":\"Wayne Fitzgerald\",\"gender\":\"male\",\
-        \"address\":\"Studio 3,William alley,New Bethan,WR4V 7TA\",\
-        \"date_of_birth\":-336700800000,\"email_address\":\"wayne_fitzgerald@hotmail.com\",\
-        \"height_cm\":187,\"weight_kg\":52,\"account_create_date\":1641254400000,\
-        \"bike_serial\":\"SN0000\",\"original_source\":\"offline\"}\n"
-    ) == {'user_id': 815, 'start_time': datetime.strptime('25/07/2022 16:13:37.209120', "%d/%m/%Y %H:%M:%S.%f") - timedelta(seconds=0.5)}
-
-
-def test_invalid_ride_data_from_log_line():
-    """Test for the get_ride_data_from_log_line function where all fields are not present."""
-
-    assert get_ride_data_from_log_line(
-        "mendoza v9: [SYSTEM] data = \
-        {\"name\":\"Wayne Fitzgerald\",\"gender\":\"male\",\
-        \"address\":\"Studio 3,William alley,New Bethan,WR4V 7TA\",\
-        \"date_of_birth\":-336700800000,\"email_address\":\"wayne_fitzgerald@hotmail.com\",\
-        \"height_cm\":187,\"weight_kg\":52,\"account_create_date\":1641254400000,\
-        \"bike_serial\":\"SN0000\",\"original_source\":\"offline\"}\n"
-    ) == {'user_id': None, 'start_time': None}
 
 
 def test_valid_reading_data_from_log_line():


### PR DESCRIPTION
Before these changes, log lines could come from Kafka where the start time for this current ride came _before_ that of the previous ride, which is not possible. This leads to complications when looking at the longest rides per user, as if a start time was given as a year earlier than it actually is, then since the elapsed time (duration) is computed from the start time, this results in a ride that is a year long. 

To remediate this issue, for each new start time that comes in, the `transform.py` script has now been added to query the database for the start time of the previous ride. Should the start time of the current ride come after the start time of the previous ride, then no issues, otherwise, we can only set the start time to be None. 

Lastly, it will be the case that the elapsed_time for this ride will have to be None also as a result of this erroneous data. This is because the elapsed_time is computed from the start time. The elapsed_time is computed in `get_reading_data_from_log_line` which contains a start_time argument and is called in the `pipeline.py` script. Without reworking the entire pipeline, I think this rare case of an invalid start_time having no duration but keeping all other metrics is best.