### PR TITLE
Fixing pipeline timestamp bug

### DIFF
--- a/pipeline/load.py
+++ b/pipeline/load.py
@@ -59,7 +59,7 @@ def add_reading(db_connection: connection, reading: dict) -> int:
         db_connection.commit()
         return reading_id
 
-    except errors.UniqueViolation:
+    except (errors.UniqueViolation, errors.NotNullViolation):
         db_connection.rollback()
         reading_id = database_functions.select_reading_from_database(db_connection, reading)
         return reading_id

--- a/pipeline/load.py
+++ b/pipeline/load.py
@@ -89,7 +89,7 @@ def add_readings_from_csv(db_connection: connection, readings_file: str) -> bool
         database_functions.load_readings_into_database_from_csv(db_connection, readings_file)
         db_connection.commit()
 
-    except errors.UniqueViolation:
+    except (errors.UniqueViolation, errors.NotNullViolation):
         db_connection.rollback()
         # We don't know which record caused the unique violation, so have to individually insert all.
         readings = pd.read_csv(readings_file).to_dict("records")

--- a/pipeline/pipeline.py
+++ b/pipeline/pipeline.py
@@ -203,7 +203,7 @@ class Pipeline():
         if len(self._consecutive_extreme_hrs) == self._extreme_hr_count_threshold:
             try:
                 validate_heart_rate.send_email(self._rider, self._consecutive_extreme_hrs)
-                logging.info('HR Alert email sent to rider.')
+                logging.info('HR alert email sent to rider.')
             except ClientError as e:
                 logging.error('Unable to send email; %s', str(e))
 

--- a/pipeline/pipeline.py
+++ b/pipeline/pipeline.py
@@ -111,7 +111,6 @@ class KafkaConnection():
         the message before last, if system_message_before_last is True) fetched the next time the
         partition is accessed.
         """
-        print('saving')
         if system_message_before_last:
             message = self._pre_system_messages[-2]
         else:
@@ -204,6 +203,7 @@ class Pipeline():
         if len(self._consecutive_extreme_hrs) == self._extreme_hr_count_threshold:
             try:
                 validate_heart_rate.send_email(self._rider, self._consecutive_extreme_hrs)
+                logging.info('HR Alert email sent to rider.')
             except ClientError as e:
                 logging.error('Unable to send email; %s', str(e))
 
@@ -317,6 +317,10 @@ class BackfillPipeline(Pipeline):
 
         with Pool() as pool:
             readings = pd.DataFrame(pool.map(partial_reading_pipeline, reading_line_pairs))
+        
+        readings = readings.dropna()
+        integer_columns = ['heart_rate', 'rpm', 'resistance', 'elapsed_time']
+        readings[integer_columns] = readings[integer_columns].astype(int)
 
         readings.to_csv(readings_csv_file, index=False)
 

--- a/pipeline/transform.py
+++ b/pipeline/transform.py
@@ -32,8 +32,14 @@ def extract_datetime_from_string(input_string: str) -> datetime | None:
     a datetime in the format 'YYYY-MM-DD HH:MM:SS.microseconds'."""
     datetime_str = " ".join(input_string.split(" ")[:2])
     try:
+        if '.' in input_string:
+            datetime_format = '%Y-%m-%d %H:%M:%S.%f'
+        else:
+            datetime_format = '%Y-%m-%d %H:%M:%S'
+            
         datetime_obj = datetime.strptime(
-            datetime_str, '%Y-%m-%d %H:%M:%S.%f')
+            datetime_str, datetime_format)
+
         if check_datetime_is_valid(datetime_obj):
             return datetime_obj
     except (ValueError, AttributeError):


### PR DESCRIPTION
Pipeline crashed because we had a timestamp come through without a decimal second count (see attached image).
<img width="931" alt="Screenshot 2024-01-15 at 18 12 44" src="https://github.com/lcawood/deloton-bike-analysis-project/assets/143012198/3c7231c7-e91e-4efc-80b1-a89ff5221eb3">
Code ammended:
- `transform.py` – convert string to datetime differently depending on whether there is a decimalisation of seconds
- `load.py` – `add_reading()` and `add_readings()` have had null row exceptions added to their try and excepts; ensures the pipeline keeps running if specific readings can't be added
- `pipeline.py` – `BackfillPipeline` altered to drop null rows and explicitly make certain columns integer in the df before saving to file, so that the copy_from csv doesn't fail on a null row (have also made a small logging alteration)

Have tested locally, and all appears to be working; hopefully will also prevent future log line anomalies from taking down the pipeline.
